### PR TITLE
fix(ci): release-please PRs use RENOVATE_TOKEN so CI actually runs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,16 @@ jobs:
         id: rp
         with:
           release-type: simple
+          # The default GITHUB_TOKEN never triggers CI on the PRs it opens,
+          # so the release PR's required checks would never run.
+          token: ${{ secrets.RENOVATE_TOKEN }}
+
+      - name: Enable auto-merge on the release PR
+        if: ${{ steps.rp.outputs.prs_created == 'true' && steps.rp.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+        run: gh pr merge --auto --squash "${{ fromJSON(steps.rp.outputs.pr).number }}" --repo "${{ github.repository }}" || true
+
       - uses: actions/checkout@v7
       - name: tag major and minor versions
         if: ${{ steps.rp.outputs.release_created }}


### PR DESCRIPTION
Same fix applied elsewhere in the fleet: the default GITHUB_TOKEN doesn't trigger workflow runs on the PRs it opens, so the release PR's required checks never ran (PR #108 shows zero checks currently). Also arms auto-merge on the release PR.